### PR TITLE
Allow helper function during code scoring

### DIFF
--- a/pyplas/handlers/main_handler.py
+++ b/pyplas/handlers/main_handler.py
@@ -30,7 +30,8 @@ class MainHandler(ApplicationHandler):
             FROM pages 
             LEFT OUTER JOIN categories AS cat ON pages.category = cat.cat_id
             LEFT OUTER JOIN user.progress ON pages.p_id = user.progress.p_id
-            WHERE (cat.cat_name = :cat_name OR cat.cat_name is :cat_name) AND pages.status = 1"""
+            WHERE (cat.cat_name = :cat_name OR cat.cat_name is :cat_name) AND pages.status = 1
+            ORDER BY order_index ASC, register_at ASC"""
             p_list = g.db.get_from_db(sql, cat_name=cat_name)
             p_list = [r for r in p_list]
             cat = []

--- a/pyplas/handlers/problem_handler.py
+++ b/pyplas/handlers/problem_handler.py
@@ -12,6 +12,7 @@ import tornado
 
 from .app_handler import ApplicationHandler, InvalidJSONError
 from pyplas.utils import get_logger, globals as g
+from pyplas.utils.helper import add_PYTHONPATH
 import pyplas.config as cfg
 
 mylogger = get_logger(__name__)
@@ -293,6 +294,8 @@ class ProblemHandler(ApplicationHandler):
             toastに表示される文字列
         """
         code = "\n".join(self.json["answers"] + self.target_answers)
+        env = add_PYTHONPATH(os.getcwd())
+
         with tempfile.NamedTemporaryFile(delete=True, dir=cfg.PYTHON_TEMP_DIR, suffix=".py") as tmp:
             file_path = os.path.join(cfg.PYTHON_TEMP_DIR, tmp.name)
             with open(file_path, "w") as f:
@@ -300,7 +303,8 @@ class ProblemHandler(ApplicationHandler):
 
             process = subprocess.Popen(["python", file_path],
                                        stdout=subprocess.PIPE, 
-                                       stderr=subprocess.PIPE)
+                                       stderr=subprocess.PIPE,
+                                       env=env)
             ProblemHandler.execute_pool[self.json["kernel_id"]] = process
             future = IOLoop.current().run_in_executor(None, process.communicate)
             stdout, stderr = await future 

--- a/pyplas/utils/helper.py
+++ b/pyplas/utils/helper.py
@@ -30,3 +30,14 @@ def validate_json(js, schema_name):
         json_schema = json.load(j)
 
     validate(js, json_schema)
+
+def add_PYTHONPATH(path: str) -> dict:
+    """
+    環境変数PYTHONPATHにpathを追加した環境変数のdictを返す
+    """
+
+    # add path to PYTHONPATH
+    python_path = os.pathsep.join([os.environ.get("PYTHONPATH", ""), path])
+
+    env = os.environ.copy()
+    return env | {"PYTHONPATH": python_path}


### PR DESCRIPTION
Fixed a bug that helper functions could not be iported when code scoring 
(The current directory is addeed to PYTHONPATH when Popen is instantiated.)