### PR TITLE
add top margin to sidebar

### DIFF
--- a/pyplas/static/css/style.css
+++ b/pyplas/static/css/style.css
@@ -34,7 +34,7 @@
 @media (min-width: 993px) { 
   .sidebar {
     position: sticky;
-    top: 10%;
+    top: 75px;
     overflow-y: auto;
     max-height: calc(100vh);
   }


### PR DESCRIPTION
sticky sidebarのtopスペースを`10%`から`75px`に変更してノートパソコンでもUIが崩れないように修正